### PR TITLE
Fix account number mismatch when adding new users

### DIFF
--- a/src/main/java/com/mycompany/banksystem/AddUsersForm.java
+++ b/src/main/java/com/mycompany/banksystem/AddUsersForm.java
@@ -135,11 +135,9 @@ public class AddUsersForm extends javax.swing.JFrame {
             JOptionPane.showMessageDialog(null, "Please fill in all fields.", "Input Error", JOptionPane.ERROR_MESSAGE);
         } else {
             
-            AdminMethods adminMethods = new AdminMethods();  // Create reference to AdminMethods class
-            
-            // Generate a unique account number for the new user
-             int accountNumber = AdminMethods.generateAccountNumber();
-            adminMethods.addUserToDatabase(username, password, role);  // Call the method to add the user
+        AdminMethods adminMethods = new AdminMethods();  // Create reference to AdminMethods class
+
+            int accountNumber = adminMethods.addUserToDatabase(username, password, role);  // Add user and get generated account number
 
               // Show success message with the account number
            JOptionPane.showMessageDialog(null, "User added successfully! Account Number: " + accountNumber, "Success", JOptionPane.INFORMATION_MESSAGE);

--- a/src/main/java/com/mycompany/banksystem/AdminMethods.java
+++ b/src/main/java/com/mycompany/banksystem/AdminMethods.java
@@ -71,7 +71,7 @@ public class AdminMethods {
      * @param password The password of the new user (not hashed for simplicity).
      * @param role The role of the new user (default: "user").
      */
-    public static void addUserToDatabase(String username, String password, String role) {
+    public static int addUserToDatabase(String username, String password, String role) {
         int accountNumber = generateAccountNumber();
         String userQuery = "INSERT INTO Users (username, password, role) VALUES (?, ?, 'user')";
 
@@ -81,9 +81,11 @@ public class AdminMethods {
             stmt.executeUpdate();
             System.out.println("User added successfully.");
             addAccount(accountNumber, username);
+            return accountNumber;
         } catch (SQLException e) {
             e.printStackTrace();
         }
+        return -1;
     }
 
     /**

--- a/src/main/java/com/mycompany/banksystem/BankSystem.java
+++ b/src/main/java/com/mycompany/banksystem/BankSystem.java
@@ -115,7 +115,8 @@ public class BankSystem {
                     String newPassword = scanner.next();
                     String role = "user";
 
-                    adminMethods.addUserToDatabase(newUsername, newPassword, role);
+                    int accNum = adminMethods.addUserToDatabase(newUsername, newPassword, role);
+                    System.out.println("User added successfully. Account Number: " + accNum);
                     break;
                 case 2:
                     adminMethods.getAllUsers();


### PR DESCRIPTION
## Summary
- return the generated account number from `AdminMethods.addUserToDatabase`
- show correct account number when adding users via GUI and console

## Testing
- `javac @sources.txt` *(compilation succeeds)*
- `mvn -q -e test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6859f23c7b6c83249e313022e551ac8b